### PR TITLE
Minor fix for api status code handling

### DIFF
--- a/TMDBTraktSyncer/errorHandling.py
+++ b/TMDBTraktSyncer/errorHandling.py
@@ -39,7 +39,7 @@ def make_trakt_request(url, headers=None, payload=None, max_retries=3):
             else:
                 response = requests.post(url, headers=headers, json=payload)
 
-            if response.status_code == 200:
+            if response.status_code in [200, 201, 204]:
                 return response  # Request succeeded, return response
             elif response.status_code in [429, 502, 503, 504, 520, 521, 522]:
                 # Server overloaded or rate limit exceeded, retry after delay
@@ -106,9 +106,9 @@ def make_tmdb_request(url, headers=None, payload=None, max_retries=3):
                 response = requests.post(url, headers=headers, json=payload)
 
             status_code = response.status_code
-            if status_code == 200:
+            if status_code in [1, 12, 13]:
                 return response  # Request succeeded, return response
-            elif status_code == 429:
+            elif status_code in [24, 25, 43, 46, 429]:
                 # Rate limit exceeded, retry after delay
                 retry_attempts += 1
                 time.sleep(retry_delay)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.0.8'
+VERSION = '1.0.9'
 DESCRIPTION = 'This python script will sync user ratings for Movies and TV Shows both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
- Add all success codes so they are handled properly. In v1.0.8 some success status codes were being handled as errors. This would print an error message even when the request was completed successfully. 
- Add some other status codes to retry when failed. (e.g. API down for maintenance and other unavailable errors)