### PR TITLE
Fix for status api code handling

### DIFF
--- a/TMDBTraktSyncer/errorHandling.py
+++ b/TMDBTraktSyncer/errorHandling.py
@@ -41,7 +41,7 @@ def make_trakt_request(url, headers=None, payload=None, max_retries=3):
 
             if response.status_code in [200, 201, 204]:
                 return response  # Request succeeded, return response
-            elif response.status_code in [429, 502, 503, 504, 520, 521, 522]:
+            elif response.status_code in [429, 500, 502, 503, 504, 520, 521, 522]:
                 # Server overloaded or rate limit exceeded, retry after delay
                 retry_attempts += 1
                 time.sleep(retry_delay)
@@ -106,9 +106,9 @@ def make_tmdb_request(url, headers=None, payload=None, max_retries=3):
                 response = requests.post(url, headers=headers, json=payload)
 
             status_code = response.status_code
-            if status_code in [1, 12, 13]:
+            if status_code in [200, 201]:
                 return response  # Request succeeded, return response
-            elif status_code in [24, 25, 43, 46, 429]:
+            elif status_code in [504, 429, 502, 503]:
                 # Rate limit exceeded, retry after delay
                 retry_attempts += 1
                 time.sleep(retry_delay)
@@ -135,53 +135,54 @@ def make_tmdb_request(url, headers=None, payload=None, max_retries=3):
 
 def get_tmdb_message(status_code):
     error_messages = {
-        1: "Success",
-        2: "Invalid service: this service does not exist",
-        3: "Authentication failed: You do not have permissions to access the service",
-        4: "Invalid format: This service doesn't exist in that format",
-        5: "Invalid parameters: Your request parameters are incorrect",
-        6: "Invalid id: The pre-requisite id is invalid or not found",
-        7: "Invalid API key: You must be granted a valid key",
-        8: "Duplicate entry: The data you tried to submit already exists",
-        9: "Service offline: This service is temporarily offline, try again later",
-        10: "Suspended API key: Access to your account has been suspended, contact TMDB",
-        11: "Internal error: Something went wrong, contact TMDB",
-        12: "The item/record was updated successfully",
-        13: "The item/record was deleted successfully",
-        14: "Authentication failed",
-        15: "Failed",
-        16: "Device denied",
-        17: "Session denied",
-        18: "Validation failed",
-        19: "Invalid accept header",
-        20: "Invalid date range: Should be a range no longer than 14 days",
-        21: "Entry not found: The item you are trying to edit cannot be found",
-        22: "Invalid page: Pages start at 1 and max at 1000. They are expected to be an integer",
-        23: "Invalid date: Format needs to be YYYY-MM-DD",
-        24: "Your request to the backend server timed out. Try again",
-        25: "Your request count is over the allowed limit",
-        26: "You must provide a username and password",
-        27: "Too many append to response objects: The maximum number of remote calls is 20",
-        28: "Invalid timezone: Please consult the documentation for a valid timezone",
-        29: "You must confirm this action: Please provide a confirm=true parameter",
-        30: "Invalid username and/or password: You did not provide a valid login",
-        31: "Account disabled: Your account is no longer active. Contact TMDB if this is an error",
-        32: "Email not verified: Your email address has not been verified",
-        33: "Invalid request token: The request token is either expired or invalid",
-        34: "The resource you requested could not be found",
-        35: "Invalid token",
-        36: "This token hasn't been granted write permission by the user",
-        37: "The requested session could not be found",
-        38: "You don't have permission to edit this resource",
-        39: "This resource is private",
-        40: "Nothing to update",
-        41: "This request token hasn't been approved by the user",
-        42: "This request method is not supported for this resource",
-        43: "Couldn't connect to the backend server",
-        44: "The ID is invalid",
-        45: "This user has been suspended",
-        46: "The API is undergoing maintenance. Try again later",
-        47: "The input is not valid"
+        200: "Success",
+        501: "Invalid service: this service does not exist",
+        401: "Authentication failed: You do not have permissions to access the service",
+        405: "Invalid format: This service doesn't exist in that format",
+        422: "Invalid parameters: Your request parameters are incorrect",
+        404: "Invalid id: The pre-requisite id is invalid or not found",
+        401: "Invalid API key: You must be granted a valid key",
+        403: "Duplicate entry: The data you tried to submit already exists",
+        503: "Service offline: This service is temporarily offline, try again later",
+        401: "Suspended API key: Access to your account has been suspended, contact TMDB",
+        500: "Internal error: Something went wrong, contact TMDB",
+        201: "The item/record was updated successfully",
+        200: "The item/record was deleted successfully",
+        401: "Authentication failed",
+        500: "Failed",
+        401: "Device denied",
+        401: "Session denied",
+        400: "Validation failed",
+        406: "Invalid accept header",
+        422: "Invalid date range: Should be a range no longer than 14 days",
+        200: "Entry not found: The item you are trying to edit cannot be found",
+        400: "Invalid page: Pages start at 1 and max at 1000. They are expected to be an integer",
+        400: "Invalid date: Format needs to be YYYY-MM-DD",
+        504: "Your request to the backend server timed out. Try again",
+        429: "Your request count (#) is over the allowed limit of (40)",
+        400: "You must provide a username and password",
+        400: "Too many append to response objects: The maximum number of remote calls is 20",
+        400: "Invalid timezone: Please consult the documentation for a valid timezone",
+        400: "You must confirm this action: Please provide a confirm=true parameter",
+        401: "Invalid username and/or password: You did not provide a valid login",
+        401: "Account disabled: Your account is no longer active. Contact TMDB if this is an error",
+        401: "Email not verified: Your email address has not been verified",
+        401: "Invalid request token: The request token is either expired or invalid",
+        404: "The resource you requested could not be found",
+        401: "Invalid token",
+        401: "This token hasn't been granted write permission by the user",
+        404: "The requested session could not be found",
+        401: "You don't have permission to edit this resource",
+        401: "This resource is private",
+        200: "Nothing to update",
+        422: "This request token hasn't been approved by the user",
+        405: "This request method is not supported for this resource",
+        502: "Couldn't connect to the backend server",
+        500: "The ID is invalid",
+        403: "This user has been suspended",
+        503: "The API is undergoing maintenance. Try again later",
+        400: "The input is not valid"
     }
 
     return error_messages.get(status_code, "Unknown error")
+

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.0.9'
+VERSION = '1.1.0'
 DESCRIPTION = 'This python script will sync user ratings for Movies and TV Shows both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
- In v1.0.8 and v1.0.9 some success status codes were being handled as errors. 
- Add some other status codes to retry when failed. (e.g. API down for maintenance and other unavailable errors)