### PR TITLE
Fix for script failing with some usernames

### DIFF
--- a/TMDBTraktSyncer/traktData.py
+++ b/TMDBTraktSyncer/traktData.py
@@ -1,5 +1,6 @@
 import json
 import requests
+import urllib.parse
 try:
     from TMDBTraktSyncer import errorHandling as EH
 except ImportError:
@@ -11,8 +12,9 @@ def getTraktRatings(trakt_client_id, trakt_access_token):
 
     response = EH.make_trakt_request('https://api.trakt.tv/users/me')
     json_data = json.loads(response.text)
-    username = json_data['username']
-    response = EH.make_trakt_request(f'https://api.trakt.tv/users/{username}/ratings')
+    username_slug = json_data['ids']['slug']
+    encoded_username = urllib.parse.quote(username_slug)
+    response = EH.make_trakt_request(f'https://api.trakt.tv/users/{encoded_username}/ratings')
     json_data = json.loads(response.text)
 
     movie_ratings = []

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.1.4'
+VERSION = '1.1.6'
 DESCRIPTION = 'This python script will sync user ratings for Movies and TV Shows both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
- Script will now correctly pull username via their url slug instead of their username directly. This will fix the script breaking for users where their username is different than their username url slug.