### PR TITLE
Add support for updating ratings with most recent rating

### DIFF
--- a/TMDBTraktSyncer/TMDBTraktSyncer.py
+++ b/TMDBTraktSyncer/TMDBTraktSyncer.py
@@ -1,6 +1,7 @@
 import json
 import requests
 import time
+from datetime import datetime
 try:
     from TMDBTraktSyncer import verifyCredentials as VC
     from TMDBTraktSyncer import traktData
@@ -19,7 +20,7 @@ def main():
     try:
             
         trakt_watchlist, trakt_ratings, watched_content = traktData.getTraktData()
-        tmdb_watchlist, tmdb_ratings = tmdbData.getTMDBRatings()
+        tmdb_watchlist, tmdb_ratings = tmdbData.getTMDBData()
 
         #Get trakt and tmdb ratings and filter out trakt ratings with missing tmdb id
         trakt_ratings = [rating for rating in trakt_ratings if rating['TMDB_ID'] is not None]
@@ -31,6 +32,38 @@ def main():
         trakt_ratings_to_set = [rating for rating in tmdb_ratings if rating['TMDB_ID'] not in [trakt_rating['TMDB_ID'] for trakt_rating in trakt_ratings]]
         tmdb_watchlist_to_set = [item for item in trakt_watchlist if item['TMDB_ID'] not in [tmdb_item['TMDB_ID'] for tmdb_item in tmdb_watchlist]]
         trakt_watchlist_to_set = [item for item in tmdb_watchlist if item['TMDB_ID'] not in [trakt_item['TMDB_ID'] for trakt_item in trakt_watchlist]]
+        
+        # Filter ratings to update
+        tmdb_ratings_to_update = []
+        trakt_ratings_to_update = []
+
+        # Dictionary to store TMDB_IDs and their corresponding ratings for TMDB and Trakt
+        tmdb_ratings_dict = {rating['TMDB_ID']: rating for rating in tmdb_ratings}
+        trakt_ratings_dict = {rating['TMDB_ID']: rating for rating in trakt_ratings}
+
+        # Include only items with the same TMDB_ID and different ratings and prefer the most recent rating
+        for tmdb_id, tmdb_rating in tmdb_ratings_dict.items():
+            if tmdb_id in trakt_ratings_dict:
+                trakt_rating = trakt_ratings_dict[tmdb_id]
+                # Convert ratings to float before comparing
+                tmdb_rating_value = float(tmdb_rating['Rating'])
+                trakt_rating_value = float(trakt_rating['Rating'])
+                
+                if tmdb_rating_value != trakt_rating_value:
+                    # Check if both tmdb_rating and trakt_rating have Date_Added values
+                    if tmdb_rating['Date_Added'] is not None and trakt_rating['Date_Added'] is not None:
+                        tmdb_date_added = datetime.fromisoformat(tmdb_rating['Date_Added'])
+                        trakt_date_added = datetime.fromisoformat(trakt_rating['Date_Added'])
+                    
+                        # If TMDB rating is more recent, add the Trakt rating to the update list, and vice versa
+                        if tmdb_date_added > trakt_date_added:
+                            trakt_ratings_to_update.append(tmdb_rating)
+                        else:
+                            tmdb_ratings_to_update.append(trakt_rating)
+
+        # Update ratings_to_set
+        tmdb_ratings_to_set.extend(tmdb_ratings_to_update)
+        trakt_ratings_to_set.extend(trakt_ratings_to_update)
         
         # If remove_watched_from_watchlists_value is true
         if VC.remove_watched_from_watchlists_value:        

--- a/TMDBTraktSyncer/tmdbData.py
+++ b/TMDBTraktSyncer/tmdbData.py
@@ -16,7 +16,7 @@ def fetch_data(url):
     current_page = json_data['page']
     return results, total_pages, current_page
 
-def getTMDBRatings():
+def getTMDBData():
     print('Processing TMDB Data')
 
     # Fetch Account ID
@@ -60,11 +60,11 @@ def getTMDBRatings():
     total_pages = 1
 
     while page <= total_pages:
-        url = f'https://api.themoviedb.org/3/account/{account_id}/rated/movies?page={page}'
+        url = f'https://api.themoviedb.org/4/account/{account_id}/movie/rated?page={page}'
         results, total_pages, _ = fetch_data(url)
         
         for movie in results:
-            movie_ratings.append({'Title': movie['title'], 'Year': movie['release_date'][:4], 'Rating': movie['rating'], 'TMDB_ID': movie['id'], 'Type': 'movie'})
+            movie_ratings.append({'Title': movie['title'], 'Year': movie['release_date'][:4], 'Rating': movie['account_rating']['value'], 'TMDB_ID': movie['id'], 'Date_Added': movie['account_rating']['created_at'], 'Type': 'movie'})
         
         page += 1
 
@@ -74,11 +74,11 @@ def getTMDBRatings():
     total_pages = 1
 
     while page <= total_pages:
-        url = f'https://api.themoviedb.org/3/account/{account_id}/rated/tv?page={page}'
+        url = f'https://api.themoviedb.org/4/account/{account_id}/tv/rated?page={page}'
         results, total_pages, _ = fetch_data(url)
         
         for show in results:
-            show_ratings.append({'Title': show['name'], 'Year': show['first_air_date'][:4], 'Rating': show['rating'], 'TMDB_ID': show['id'], 'Type': 'show'})
+            show_ratings.append({'Title': show['name'], 'Year': show['first_air_date'][:4], 'Rating': show['account_rating']['value'], 'TMDB_ID': show['id'], 'Date_Added': movie['account_rating']['created_at'], 'Type': 'show'})
         
         page += 1
 
@@ -105,6 +105,7 @@ def getTMDBRatings():
                 'Season': episode.get('season_number'),
                 'Episode': episode.get('episode_number'),
                 'ShowID': show_id,
+                'Date_Added': None,
                 'Type': 'episode'
             })
             

--- a/TMDBTraktSyncer/traktData.py
+++ b/TMDBTraktSyncer/traktData.py
@@ -29,12 +29,12 @@ def getTraktData():
             movie = item.get('movie')
             tmdb_movie_id = movie.get('ids', {}).get('tmdb')
             trakt_movie_id = movie.get('ids', {}).get('trakt')
-            trakt_watchlist.append({'Title': movie.get('title'), 'Year': movie.get('year'), "TMDB_ID": tmdb_movie_id, 'TraktID': trakt_movie_id, 'Type': 'movie'})
+            trakt_watchlist.append({'Title': movie.get('title'), 'Year': movie.get('year'), "TMDB_ID": tmdb_movie_id, 'TraktID': trakt_movie_id, 'Date_Added': item.get('listed_at'), 'Type': 'movie'})
         elif item['type'] == 'show':
             show = item.get('show')
             tmdb_show_id = show.get('ids', {}).get('tmdb')
             trakt_show_id = show.get('ids', {}).get('trakt')
-            trakt_watchlist.append({'Title': show.get('title'), 'Year': show.get('year'), "TMDB_ID": tmdb_show_id, 'TraktID': trakt_show_id, 'Type': 'show'})
+            trakt_watchlist.append({'Title': show.get('title'), 'Year': show.get('year'), "TMDB_ID": tmdb_show_id, 'TraktID': trakt_show_id, 'Date_Added': item.get('listed_at'), 'Type': 'show'})
 
     # Get Trakt Ratings
     response = EH.make_trakt_request(f'https://api.trakt.tv/users/{encoded_username}/ratings')
@@ -48,11 +48,11 @@ def getTraktData():
         if item['type'] == 'movie':
             movie = item.get('movie')
             movie_id = movie.get('ids', {}).get('tmdb')
-            movie_ratings.append({'Title': movie.get('title'), 'Year': movie.get('year'), 'Rating': item.get('rating'), "TMDB_ID": movie_id, 'Type': 'movie'})
+            movie_ratings.append({'Title': movie.get('title'), 'Year': movie.get('year'), 'Rating': item.get('rating'), "TMDB_ID": movie_id, 'Date_Added': item.get('rated_at'), 'Type': 'movie'})
         elif item['type'] == 'show':
             show = item.get('show')
             show_id = show.get('ids', {}).get('tmdb')
-            show_ratings.append({'Title': show.get('title'), 'Year': show.get('year'), 'Rating': item.get('rating'), "TMDB_ID": show_id, 'Type': 'show'})
+            show_ratings.append({'Title': show.get('title'), 'Year': show.get('year'), 'Rating': item.get('rating'), "TMDB_ID": show_id, 'Date_Added': item.get('rated_at'), 'Type': 'show'})
         elif item['type'] == 'episode':
             show = item.get('show')
             show_title = show.get('title')
@@ -68,6 +68,7 @@ def getTraktData():
                 'Season': episode.get('season'),
                 'Episode': episode.get('number'),
                 'TMDB_ShowID': show_tmdb_id,
+                'Date_Added': item.get('rated_at'),
                 'Type': 'episode'
             })
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.4.1'
+VERSION = '1.5.0'
 DESCRIPTION = 'A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
- Pull request adds support for updating ratings with the user's most recent rating for Movies and TV Shows

### Notes:
Pull request adds support for updating ratings with the user's most recent rating for Movies and TV Shows. Updating episode ratings is currently not supported. This is due to a TMDB limitation. Currently it is not possible to get the `created_at` date for episode ratings via TMDB [v3](https://developer.themoviedb.org/reference/) and [v4](https://developer.themoviedb.org/v4/reference/intro/getting-started) endpoints. 

I requested two new features on the TMDB API support forum which would add support for getting the `created_at` date for episode ratings but have not heard back on any updates as of yet. It's unclear whether these features will be added at some point in the future. For now, only updating Movie and TV Show ratings are supported.

- [[Feature Request] Add support for "Rated TV Episodes" in v4 API](https://www.themoviedb.org/talk/64b32e9023d27800e88b24d8)
- [[Feature Request] Add support for "created_at" date for getting user ratings in v3 API endpoints](https://www.themoviedb.org/talk/64b32adc78570e011da90c7c)