### PR TITLE
Fix for Trakt authentication 

### DIFF
--- a/TMDBTraktSyncer/authTrakt.py
+++ b/TMDBTraktSyncer/authTrakt.py
@@ -5,8 +5,8 @@ try:
 except ImportError:
     import errorLogger as EL
 
-def make_trakt_request(url, headers=None, params=None, payload=None, max_retries=3):
-    retry_delay = 5  # seconds between retries
+def make_trakt_request(url, headers=None, params=None, payload=None, max_retries=5):
+    retry_delay = 1  # seconds between retries
     retry_attempts = 0
 
     while retry_attempts < max_retries:
@@ -62,49 +62,70 @@ def get_trakt_message(status_code):
 
     return error_messages.get(status_code, "Unknown status code")
 
-def authenticate(client_id, client_secret):
+def authenticate(client_id, client_secret, refresh_token=None):
     CLIENT_ID = client_id
     CLIENT_SECRET = client_secret
 
     REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
 
-    # Set up the authorization endpoint URL
-    auth_url = 'https://trakt.tv/oauth/authorize'
+    if refresh_token:
+        # If a refresh token is provided, use it to get a new access token
+        data = {
+            'refresh_token': refresh_token,
+            'client_id': CLIENT_ID,
+            'client_secret': CLIENT_SECRET,
+            'redirect_uri': REDIRECT_URI,
+            'grant_type': 'refresh_token'
+        }
 
-    # Construct the authorization URL with the necessary parameters
-    params = {
-        'response_type': 'code',
-        'client_id': CLIENT_ID,
-        'redirect_uri': REDIRECT_URI,
-    }
-    auth_url += '?' + '&'.join([f'{key}={value}' for key, value in params.items()])
+        response = requests.post('https://api.trakt.tv/oauth/token', json=data)
 
-    # Print out the authorization URL and instruct the user to visit it
-    print(f'\nPlease visit the following URL to authorize this application: \n{auth_url}\n')
+        json_data = response.json()
+        ACCESS_TOKEN = json_data['access_token']
+        REFRESH_TOKEN = json_data['refresh_token']
+        return ACCESS_TOKEN, REFRESH_TOKEN
 
-    # After the user grants authorization, they will be redirected back to the redirect URI with a temporary authorization code.
-    # Extract the authorization code from the URL and use it to request an access token from the Trakt API.
-    authorization_code = input('Please enter the authorization code from the URL: ')
+    else:
+        # Set up the authorization endpoint URL
+        auth_url = 'https://trakt.tv/oauth/authorize'
 
-    # Set up the access token request
-    headers = {
-        'Content-Type': 'application/json'
-    }
-    data = {
-        'code': authorization_code,
-        'client_id': CLIENT_ID,
-        'client_secret': CLIENT_SECRET,
-        'redirect_uri': REDIRECT_URI,
-        'grant_type': 'authorization_code'
-    }
+        # Construct the authorization URL with the necessary parameters
+        params = {
+            'response_type': 'code',
+            'client_id': CLIENT_ID,
+            'redirect_uri': REDIRECT_URI,
+        }
+        auth_url += '?' + '&'.join([f'{key}={value}' for key, value in params.items()])
 
-    # Make the request to get the access token
-    response = make_trakt_request('https://api.trakt.tv/oauth/token', payload=data)
+        # Print out the authorization URL and instruct the user to visit it
+        print(f'\nPlease visit the following URL to authorize this application: \n{auth_url}\n')
 
-    # Parse the JSON response from the API
-    json_data = response.json()
+        # After the user grants authorization, they will be redirected back to the redirect URI with a temporary authorization code.
+        # Extract the authorization code from the URL and use it to request an access token from the Trakt API.
+        authorization_code = input('Please enter the authorization code from the URL: ')
 
-    # Extract the access token from the response
-    ACCESS_TOKEN = json_data['access_token']
+        # Set up the access token request
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        data = {
+            'code': authorization_code,
+            'client_id': CLIENT_ID,
+            'client_secret': CLIENT_SECRET,
+            'redirect_uri': REDIRECT_URI,
+            'grant_type': 'authorization_code'
+        }
 
-    return ACCESS_TOKEN
+        # Make the request to get the access token
+        response = requests.post('https://api.trakt.tv/oauth/token', json=data)
+
+        # Parse the JSON response from the API
+        json_data = response.json()
+
+        # Extract the access token from the response
+        ACCESS_TOKEN = json_data['access_token']
+        
+        # Extract the refresh token from the response
+        REFRESH_TOKEN = json_data['refresh_token']
+
+        return ACCESS_TOKEN, REFRESH_TOKEN

--- a/TMDBTraktSyncer/verifyCredentials.py
+++ b/TMDBTraktSyncer/verifyCredentials.py
@@ -19,6 +19,7 @@ def prompt_get_credentials():
             "trakt_client_id": "empty",
             "trakt_client_secret": "empty",
             "trakt_access_token": "empty",
+            "trakt_refresh_token": "empty",
             "tmdb_v4_token": "empty",
         }
         with open(file_path, 'w', encoding='utf-8') as f:
@@ -30,29 +31,37 @@ def prompt_get_credentials():
 
     # Check if any of the values are "empty" and prompt the user to enter them
     for key in values.keys():
-        if values[key] == "empty" and key != "trakt_access_token":
+        if values[key] == "empty" and (key != "trakt_access_token" and key != "trakt_refresh_token"):
             values[key] = input(f"Please enter a value for {key}: ").strip()
             with open(file_path, 'w', encoding='utf-8') as f:
                 json.dump(values, f)
 
-    # Get the trakt_access_token value if it exists, or run the authTrakt.py function to get it
+    # Get the trakt_refresh_token value if it exists, or run the authTrakt.py function to get it
     trakt_access_token = None
-    if "trakt_access_token" in values and values["trakt_access_token"] != "empty":
-        trakt_access_token = values["trakt_access_token"]
-    else:
-        client_id = values["trakt_client_id"]
-        client_secret = values["trakt_client_secret"]
-        trakt_access_token = authTrakt.authenticate(client_id, client_secret)
+    trakt_refresh_token = None
+    client_id = values["trakt_client_id"]
+    client_secret = values["trakt_client_secret"]
+    if "trakt_refresh_token" in values and values["trakt_refresh_token"] != "empty":
+        trakt_access_token = values["trakt_refresh_token"]
+        trakt_access_token, trakt_refresh_token = authTrakt.authenticate(client_id, client_secret, trakt_access_token)
         values["trakt_access_token"] = trakt_access_token
+        values["trakt_refresh_token"] = trakt_refresh_token
+        with open(file_path, 'w', encoding='utf-8') as f:
+            json.dump(values, f)
+    else:
+        trakt_access_token, trakt_refresh_token = authTrakt.authenticate(client_id, client_secret)
+        values["trakt_access_token"] = trakt_access_token
+        values["trakt_refresh_token"] = trakt_refresh_token
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(values, f)
 
     trakt_client_id = values["trakt_client_id"]
     trakt_client_secret = values["trakt_client_secret"]
     trakt_access_token = values["trakt_access_token"]
+    trakt_refresh_token = values["trakt_refresh_token"]
     tmdb_v4_token = values["tmdb_v4_token"]
 
-    return trakt_client_id, trakt_client_secret, trakt_access_token, tmdb_v4_token
+    return trakt_client_id, trakt_client_secret, trakt_access_token, trakt_refresh_token, tmdb_v4_token
         
 def prompt_sync_ratings():
     # Define the file path
@@ -210,7 +219,7 @@ def prompt_remove_watched_from_watchlists():
     return remove_watched_from_watchlists_value
 
 # Save the credential values as variables
-trakt_client_id, trakt_client_secret, trakt_access_token, tmdb_v4_token = prompt_get_credentials()
+trakt_client_id, trakt_client_secret, trakt_access_token, trakt_refresh_token, tmdb_v4_token = prompt_get_credentials()
 sync_ratings_value = prompt_sync_ratings()
 sync_watchlist_value = prompt_sync_watchlist()
 remove_watched_from_watchlists_value = prompt_remove_watched_from_watchlists()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.5.2'
+VERSION = '1.6.0'
 DESCRIPTION = 'A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
### What's Changed:
Fix for a bug in the script with Trakt authorization. The Trakt auth token expires after 3 months but the script was not handling this correctly. This patch fixes this be correctly reauthenticating with the Trakt refresh token.

### Notes:
Users upgrading to v1.6.0 or later will be prompted to reauthenticate Trakt. After which, the reauthentication process will no longer require further user interaction.