### PR TITLE
Improvements for removing watched items from watchlists

### DIFF
--- a/TMDBTraktSyncer/traktData.py
+++ b/TMDBTraktSyncer/traktData.py
@@ -124,10 +124,10 @@ def getTraktData():
         trakt_show_id = show['TraktID']
         show_status = show['ShowStatus']
         aired_episodes = show['AiredEpisodes']
-        episode_numbers = {episode['EpisodeNumber'] for episode in watched_episodes if episode['Type'] == 'episode' and episode['TraktShowID'] == trakt_show_id}
+        episode_numbers = [episode['EpisodeNumber'] for episode in watched_episodes if episode['Type'] == 'episode' and episode['TraktShowID'] == trakt_show_id]
         unique_watched_episode_count = len(episode_numbers)
-
-        if (show_status == 'ended' or show_status == 'cancelled') and unique_watched_episode_count >= 0.8 * int(aired_episodes):
+        
+        if (show_status.lower() in ['ended', 'cancelled', 'canceled']) and (unique_watched_episode_count >= 0.8 * int(aired_episodes)):
             filtered_watched_shows.append(show)
 
     # Update watched_shows with the filtered results

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.6.0'
+VERSION = '1.6.1'
 DESCRIPTION = 'A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
- Fixed an issue where not all episodes in a show were being counted as watched due to duplicate episode numbers being removed from a list argument. This was resulting in a 100% watched show with multiple seasons not being removed from the users watchlists.
- Fixed an issue where cancelled shows were not being removed from watchlists, this was due to a spelling issue in the Trakt API that uses the string `canceled` instead of `cancelled`. The script now handles both spelling situations.