### PR TITLE
Fix for some Trakt auth requests failing occasionally + other minor improvements

### DIFF
--- a/TMDBTraktSyncer/authTrakt.py
+++ b/TMDBTraktSyncer/authTrakt.py
@@ -8,11 +8,22 @@ except ImportError:
 def make_trakt_request(url, headers=None, params=None, payload=None, max_retries=5):
     retry_delay = 1  # seconds between retries
     retry_attempts = 0
+    
+    if headers is None:
+        headers = {
+            'Content-Type': 'application/json',
+        }
 
     while retry_attempts < max_retries:
         response = None
         try:
-            response = requests.post(url, headers=headers, json=payload)
+            if payload is None:
+                if params:
+                    response = requests.get(url, headers=headers, params=params)
+                else:
+                    response = requests.get(url, headers=headers)
+            else:
+                response = requests.post(url, headers=headers, json=payload)
 
             if response.status_code in [200, 201, 204]:
                 return response  # Request succeeded, return response
@@ -23,15 +34,21 @@ def make_trakt_request(url, headers=None, params=None, payload=None, max_retries
                 retry_delay *= 2  # Exponential backoff for retries
             else:
                 # Handle other status codes as needed
-                error_message = get_trakt_message(response.status_code)
-                print(f"Request failed with status code {response.status_code}: {error_message}")
+                status_message = get_trakt_message(response.status_code)
+                error_message = f"Request failed with status code {response.status_code}: {status_message}"
+                print(f"   - {error_message}")
+                EL.logger.error(f"{error_message}. URL: {url}")
                 return None
 
         except requests.exceptions.RequestException as e:
-            print(f"Request failed with exception: {e}")
+            error_message = f"Request failed with exception: {e}"
+            print(f"   - {error_message}")
+            EL.logger.error(error_message, exc_info=True)
             return None
 
-    print("Max retry attempts reached with Trakt API, request failed.")
+    error_message = "Max retry attempts reached with Trakt API, request failed."
+    print(f"   - {error_message}")
+    EL.logger.error(error_message)
     return None
 
 def get_trakt_message(status_code):
@@ -78,12 +95,14 @@ def authenticate(client_id, client_secret, refresh_token=None):
             'grant_type': 'refresh_token'
         }
 
-        response = requests.post('https://api.trakt.tv/oauth/token', json=data)
+        # Use make_trakt_request for the POST request
+        response = make_trakt_request('https://api.trakt.tv/oauth/token', payload=data)
 
-        json_data = response.json()
-        ACCESS_TOKEN = json_data['access_token']
-        REFRESH_TOKEN = json_data['refresh_token']
-        return ACCESS_TOKEN, REFRESH_TOKEN
+        if response:
+            json_data = response.json()
+            ACCESS_TOKEN = json_data['access_token']
+            REFRESH_TOKEN = json_data['refresh_token']
+            return ACCESS_TOKEN, REFRESH_TOKEN
 
     else:
         # Set up the authorization endpoint URL
@@ -105,9 +124,6 @@ def authenticate(client_id, client_secret, refresh_token=None):
         authorization_code = input('Please enter the authorization code from the URL: ')
 
         # Set up the access token request
-        headers = {
-            'Content-Type': 'application/json'
-        }
         data = {
             'code': authorization_code,
             'client_id': CLIENT_ID,
@@ -116,16 +132,19 @@ def authenticate(client_id, client_secret, refresh_token=None):
             'grant_type': 'authorization_code'
         }
 
-        # Make the request to get the access token
-        response = requests.post('https://api.trakt.tv/oauth/token', json=data)
+        # Use make_trakt_request for the POST request
+        response = make_trakt_request('https://api.trakt.tv/oauth/token', payload=data)
 
-        # Parse the JSON response from the API
-        json_data = response.json()
+        if response:
+            # Parse the JSON response from the API
+            json_data = response.json()
 
-        # Extract the access token from the response
-        ACCESS_TOKEN = json_data['access_token']
-        
-        # Extract the refresh token from the response
-        REFRESH_TOKEN = json_data['refresh_token']
+            # Extract the access token from the response
+            ACCESS_TOKEN = json_data['access_token']
 
-        return ACCESS_TOKEN, REFRESH_TOKEN
+            # Extract the refresh token from the response
+            REFRESH_TOKEN = json_data['refresh_token']
+
+            return ACCESS_TOKEN, REFRESH_TOKEN
+
+    return None

--- a/TMDBTraktSyncer/errorHandling.py
+++ b/TMDBTraktSyncer/errorHandling.py
@@ -102,7 +102,7 @@ def make_tmdb_request(url, headers=None, payload=None, max_retries=5):
     if headers is None:
         headers = {
             'Content-Type': 'application/json',
-            'Authorization': f'Bearer {VC.tmdb_v4_token}'
+            'Authorization': f'Bearer {VC.tmdb_access_token}'
         }
 
     retry_delay = 1  # seconds between retries

--- a/TMDBTraktSyncer/verifyCredentials.py
+++ b/TMDBTraktSyncer/verifyCredentials.py
@@ -12,22 +12,36 @@ def prompt_get_credentials():
     here = os.path.abspath(os.path.dirname(__file__))
     file_path = os.path.join(here, 'credentials.txt')
 
+    default_values = {
+        "trakt_client_id": "empty",
+        "trakt_client_secret": "empty",
+        "trakt_access_token": "empty",
+        "trakt_refresh_token": "empty",
+        "tmdb_access_token": "empty",
+    }
+
     # Check if the file exists
-    if not os.path.isfile(file_path):
-        # If the file does not exist, create it with default values
-        default_values = {
-            "trakt_client_id": "empty",
-            "trakt_client_secret": "empty",
-            "trakt_access_token": "empty",
-            "trakt_refresh_token": "empty",
-            "tmdb_v4_token": "empty",
-        }
+    if not os.path.isfile(file_path) or os.path.getsize(file_path) == 0:
+        # If the file does not exist or is empty, create it with default values
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(default_values, f)
 
-    # Load the values from the file
+    # Load the values from the file or initialize with default values
     with open(file_path, 'r', encoding='utf-8') as f:
-        values = json.load(f)
+        try:
+            values = json.load(f)
+        except json.decoder.JSONDecodeError:
+            # Handle the case where the file is empty or not a valid JSON
+            values = default_values
+
+    # Old version fallback method - Check if the old key name exists and rename it to the new name
+    if "tmdb_v4_token" in values:
+        values["tmdb_access_token"] = values.pop("tmdb_v4_token")
+
+    # Check if any default values are missing and add them if necessary
+    for key, default_value in default_values.items():
+        if key not in values:
+            values[key] = default_value
 
     # Check if any of the values are "empty" and prompt the user to enter them
     for key in values.keys():
@@ -59,9 +73,9 @@ def prompt_get_credentials():
     trakt_client_secret = values["trakt_client_secret"]
     trakt_access_token = values["trakt_access_token"]
     trakt_refresh_token = values["trakt_refresh_token"]
-    tmdb_v4_token = values["tmdb_v4_token"]
+    tmdb_access_token = values["tmdb_access_token"]
 
-    return trakt_client_id, trakt_client_secret, trakt_access_token, trakt_refresh_token, tmdb_v4_token
+    return trakt_client_id, trakt_client_secret, trakt_access_token, trakt_refresh_token, tmdb_access_token
         
 def prompt_sync_ratings():
     # Define the file path
@@ -219,7 +233,7 @@ def prompt_remove_watched_from_watchlists():
     return remove_watched_from_watchlists_value
 
 # Save the credential values as variables
-trakt_client_id, trakt_client_secret, trakt_access_token, trakt_refresh_token, tmdb_v4_token = prompt_get_credentials()
+trakt_client_id, trakt_client_secret, trakt_access_token, trakt_refresh_token, tmdb_access_token = prompt_get_credentials()
 sync_ratings_value = prompt_sync_ratings()
 sync_watchlist_value = prompt_sync_watchlist()
 remove_watched_from_watchlists_value = prompt_remove_watched_from_watchlists()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.6.1'
+VERSION = '1.6.2'
 DESCRIPTION = 'A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
- Fix for some Trakt auth requests failing. This bug was causing the script to fail occasionally when authorizing Trakt. This was due to the script not handling failed requests and retrying where necessary in `authTrakt.py`. It now handles these requests properly.
- Improvements for handling credentials in `verifyCredentials.py`
- Update `tmdb_v4_token` value to new name `tmdb_access_token`