### PR TITLE
Improvements for handling invalid Trakt refresh token

### DIFF
--- a/TMDBTraktSyncer/authTrakt.py
+++ b/TMDBTraktSyncer/authTrakt.py
@@ -103,6 +103,9 @@ def authenticate(client_id, client_secret, refresh_token=None):
             ACCESS_TOKEN = json_data['access_token']
             REFRESH_TOKEN = json_data['refresh_token']
             return ACCESS_TOKEN, REFRESH_TOKEN
+        else:
+            # empty response, invalid refresh token, prompt user to re-authenticate
+            return authenticate(CLIENT_ID, CLIENT_SECRET)
 
     else:
         # Set up the authorization endpoint URL

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.6.2'
+VERSION = '1.6.3'
 DESCRIPTION = 'A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
- Script now prompts the user to reauthenticate if the user's refresh token has expired or is invalid. Previously the script would fail if the user's refresh token was expired or invalid.