### PR TITLE
Remove unnecessary import

### DIFF
--- a/TMDBTraktSyncer/errorLogger.py
+++ b/TMDBTraktSyncer/errorLogger.py
@@ -1,7 +1,6 @@
 import os
 import logging
 import traceback
-import selenium.webdriver
 from logging.handlers import RotatingFileHandler
 
 class CustomFormatter(logging.Formatter):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.6.3'
+VERSION = '1.6.4'
 DESCRIPTION = 'A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
Pull request removes unnecessary import for `selenium.webdriver` in `errorLogger.py`. This was causing an error for users with fresh installs who didn't have the selenium module installed. Selenium is not used in TMDBTraktSyncer so this import was unnecessary. 

This project was written in tandem with IMDBTraktSyncer which uses Selenium so this line was most likely added sometime during development and should have been removed. 