### PR TITLE
Fix for potential failures when checking TMDBTraktSyncer version

### DIFF
--- a/TMDBTraktSyncer/checkVersion.py
+++ b/TMDBTraktSyncer/checkVersion.py
@@ -1,16 +1,53 @@
 import xml.etree.ElementTree as ET
 import urllib.request
 import subprocess
+import sys
 
 def get_installed_version():
+    """
+    Retrieve the installed version of the 'tmdbtraktsyncer' package.
+    First, attempts to use 'pip' directly.
+    If that fails, it falls back to calling 'sys.executable -m pip'.
+    """
+    # Try calling 'pip' directly
     try:
-        result = subprocess.run(['pip', 'show', 'tmdbtraktsyncer'], capture_output=True, text=True, check=True)
+        result = subprocess.run(
+            ['pip', 'show', 'TMDBTraktSyncer'],
+            capture_output=True,
+            text=True,
+            check=True
+        )
         for line in result.stdout.splitlines():
             if line.startswith("Version:"):
                 return line.split()[1]
     except subprocess.CalledProcessError as e:
-        print(f"Error retrieving installed version: {e}")
-        return None
+        print(f"Error: Could not retrieve version using 'pip' command directly: {e}")
+    except FileNotFoundError:
+        print("Error: 'pip' is not installed or not in PATH.")
+    except Exception as e:
+        print(f"Unexpected error during fallback to 'pip': {e}")
+    
+    print("Fallback: Try using 'sys.executable -m pip'")
+    
+    # Fallback: Attempt using 'sys.executable -m pip'
+    try:
+        result = subprocess.run(
+            [sys.executable, '-m', 'pip', 'show', 'TMDBTraktSyncer'],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith("Version:"):
+                print(line.split()[1])
+                return line.split()[1]
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Could not retrieve python version using '{sys.executable} -m pip': {e}")
+    except FileNotFoundError:
+        print(f"Error: Python executable '{sys.executable}' does not have pip installed.")
+
+    # If all attempts fail
+    return None
 
 def get_latest_version():
     try:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.8.2'
+VERSION = '1.8.3'
 DESCRIPTION = 'A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
- Change back to calling `pip` directly to check current `TMDBTraktSyncer` version. If that fails, it falls back to calling `sys.executable -m pip`. Print an unexpected error if all attempts fail, without causing the script to fail.