### PR TITLE
Fix for Trakt API Re-Authentication

### DIFF
--- a/TMDBTraktSyncer/authTrakt.py
+++ b/TMDBTraktSyncer/authTrakt.py
@@ -1,7 +1,6 @@
 import requests
 import time
 import sys
-from requests.exceptions import ConnectionError, RequestException, Timeout, TooManyRedirects, SSLError, ProxyError
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from TMDBTraktSyncer import errorHandling as EH
@@ -28,6 +27,8 @@ def authenticate(client_id, client_secret, refresh_token=None):
 
         # Use make_trakt_request for the POST request
         response = EH.make_trakt_request('https://api.trakt.tv/oauth/token', headers=headers, payload=data)
+        if response is None:
+            raise Exception("Failed to authenticate. Please check your credentials.")
 
         if response:
             json_data = response.json()
@@ -56,6 +57,8 @@ def authenticate(client_id, client_secret, refresh_token=None):
         # After the user grants authorization, they will be redirected back to the redirect URI with a temporary authorization code.
         # Extract the authorization code from the URL and use it to request an access token from the Trakt API.
         authorization_code = input('Please enter the authorization code from the URL: ')
+        if not authorization_code.strip():
+            raise ValueError("Authorization code cannot be empty.")
 
         # Set up the access token request
         data = {
@@ -71,6 +74,8 @@ def authenticate(client_id, client_secret, refresh_token=None):
         
         # Use make_trakt_request for the POST request
         response = EH.make_trakt_request('https://api.trakt.tv/oauth/token', headers=headers, payload=data)
+        if response is None:
+            raise Exception("Failed to authenticate. Please check your credentials.")
         
         if response:
             # Parse the JSON response from the API

--- a/TMDBTraktSyncer/errorHandling.py
+++ b/TMDBTraktSyncer/errorHandling.py
@@ -2,6 +2,7 @@ import traceback
 import requests
 from requests.exceptions import ConnectionError, RequestException, Timeout, TooManyRedirects, SSLError, ProxyError
 import time
+from datetime import datetime, timedelta
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '2.0.1'
+VERSION = '2.0.2'
 DESCRIPTION = 'A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB.'
 
 # Setting up


### PR DESCRIPTION
Fixes an issue where unspecified rate limiting rules were applied for re authenticating Trakt API refresh and access tokens via OAUTH, causing max retry limit error to trigger and breaking all versions 2.0.1 and below.