### PR TITLE
Fix bug when syncing episode ratings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ _Run in your operating system's native command line._
 ```
 TMDBTraktSyncer --uninstall
 ```
-_Clears cached data except user entered credentials and error logs before uninstalling. Run in your operating system's native command line._
+_Clears cached data except user entered credentials before uninstalling. Run in your operating system's native command line._
 ## Installing a Specific Version:
 ```
 python -m pip install TMDBTraktSyncer==VERSION_NUMBER
@@ -62,10 +62,10 @@ Below is a list of available commands for this package, along with a brief descr
 
 | **Command**               | **Description**                                                                                   |
 |---------------------------|---------------------------------------------------------------------------------------------------|
-| `--help`                  | List available commands                                                                           |
+| `--help`                  | List available commands                                                                               |
 | `--clear-user-data`       | Clears user-entered credentials.                                                                  |
 | `--clear-cache`           | Clears error logs and other cached data.                                                          |
-| `--uninstall`             | Clears cached data except user entered credentials and error logs before uninstalling.            |
+| `--uninstall`             | Clears cached data except user entered credentials before uninstalling.                           |
 | `--clean-uninstall`       | Clears all cached data, inluding user credentials before uninstalling.                            |
 | `--directory`             | Prints the package install directory.                                                             |
 

--- a/TMDBTraktSyncer/tmdbData.py
+++ b/TMDBTraktSyncer/tmdbData.py
@@ -107,7 +107,7 @@ def getTMDBRatings():
                 'Type': 'episode'
             })
             
-            page += 1
+        page += 1
 
     tmdb_ratings = movie_ratings + show_ratings + episode_ratings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TMDBTraktSyncer"
-version = "2.1.0"
+version = "2.1.1"
 description = "A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
Identified and fixed a bug where when getting TMDB ratings data, the `page += 1` line inside the while loop for episodes is placed inside the loop for each result, causing the loop to increment page multiple times in one iteration. This would cause only one page of user ratings results to be returned, causing the script to attempt to rate the missing ratings data.

- Original bug report: https://github.com/RileyXX/TMDB-Trakt-Syncer/issues/42