### PR TITLE
Improve logic when comparing items with outdated TMDB ID

### DIFF
--- a/TMDBTraktSyncer/TMDBTraktSyncer.py
+++ b/TMDBTraktSyncer/TMDBTraktSyncer.py
@@ -10,7 +10,7 @@ from TMDBTraktSyncer import arguments
 
 def main():
 
-    parser = argparse.ArgumentParser(description="IMDBTraktSyncer CLI")
+    parser = argparse.ArgumentParser(description="TMDBTraktSyncer CLI")
     parser.add_argument("--clear-user-data", action="store_true", help="Clears user entered credentials.")
     parser.add_argument("--clear-cache", action="store_true", help="Clears error logs and other cached data.")
     parser.add_argument("--uninstall", action="store_true", help="Clears cached data except user entered credentials before uninstalling.")
@@ -63,6 +63,10 @@ def main():
 
             trakt_watchlist, trakt_ratings, watched_content = traktData.getTraktData()
             tmdb_watchlist, tmdb_ratings = tmdbData.getTMDBRatings()
+            
+            # Filter out items that share the same Title, Year and Type, AND have non-matching IMDB_IDs
+            trakt_ratings, tmdb_ratings = EH.filter_mismatched_items(trakt_ratings, tmdb_ratings)
+            trakt_watchlist, tmdb_watchlist = EH.filter_mismatched_items(trakt_watchlist, tmdb_watchlist)
 
             #Get trakt and tmdb ratings and filter out trakt ratings with missing tmdb id
             trakt_ratings = [rating for rating in trakt_ratings if rating['TMDB_ID'] is not None]

--- a/TMDBTraktSyncer/arguments.py
+++ b/TMDBTraktSyncer/arguments.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import os
 import platform
+import stat
 
 def try_remove(file_path, retries=3, delay=1):
     """

--- a/TMDBTraktSyncer/checkVersion.py
+++ b/TMDBTraktSyncer/checkVersion.py
@@ -6,30 +6,7 @@ import sys
 def get_installed_version():
     """
     Retrieve the installed version of the 'tmdbtraktsyncer' package.
-    First, attempts to use 'pip' directly.
-    If that fails, it falls back to calling 'sys.executable -m pip'.
     """
-    # Try calling 'pip' directly
-    try:
-        result = subprocess.run(
-            ['pip', 'show', 'TMDBTraktSyncer'],
-            capture_output=True,
-            text=True,
-            check=True
-        )
-        for line in result.stdout.splitlines():
-            if line.startswith("Version:"):
-                return line.split()[1]
-    except subprocess.CalledProcessError as e:
-        print(f"Error: Could not retrieve version using 'pip' command directly: {e}")
-    except FileNotFoundError:
-        print("Error: 'pip' is not installed or not in PATH.")
-    except Exception as e:
-        print(f"Unexpected error during fallback to 'pip': {e}")
-    
-    print("Fallback: Try using 'sys.executable -m pip'")
-    
-    # Fallback: Attempt using 'sys.executable -m pip'
     try:
         result = subprocess.run(
             [sys.executable, '-m', 'pip', 'show', 'TMDBTraktSyncer'],
@@ -42,7 +19,7 @@ def get_installed_version():
                 print(line.split()[1])
                 return line.split()[1]
     except subprocess.CalledProcessError as e:
-        print(f"Error: Could not retrieve python version using '{sys.executable} -m pip': {e}")
+        print(f"Error: Could not retrieve TMDBTraktSyncer version using '{sys.executable} -m pip': {e}")
     except FileNotFoundError:
         print(f"Error: Python executable '{sys.executable}' does not have pip installed.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TMDBTraktSyncer"
-version = "2.1.1"
+version = "2.1.2"
 description = "A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
Ignore processing items with matching Title, Year and Type, AND have non-matching TMDB IDs. This is to prevent outdated TMDB IDs from interfering with the comparison logic. This prevents the script from failing to process the same items on each run.