### PR TITLE
Use temporary sets and set lookups to speedup filtering

### DIFF
--- a/TMDBTraktSyncer/TMDBTraktSyncer.py
+++ b/TMDBTraktSyncer/TMDBTraktSyncer.py
@@ -97,6 +97,13 @@ def main():
             tmdb_watchlist_to_set = [item for item in trakt_watchlist if item['TMDB_ID'] not in [tmdb_item['TMDB_ID'] for tmdb_item in tmdb_watchlist]]
             trakt_watchlist_to_set = [item for item in tmdb_watchlist if item['TMDB_ID'] not in [trakt_item['TMDB_ID'] for trakt_item in trakt_watchlist]]
             
+            # Filter out items already set: Filters items from the target_list that are not already present in the source_list based on key
+            tmdb_ratings_to_set = EH.filter_items(tmdb_ratings, trakt_ratings, key="TMDB_ID")
+            trakt_ratings_to_set = EH.filter_items(trakt_ratings, tmdb_ratings, key="TMDB_ID")
+
+            tmdb_watchlist_to_set = EH.filter_items(tmdb_watchlist, trakt_watchlist, key="TMDB_ID")
+            trakt_watchlist_to_set = EH.filter_items(trakt_watchlist, tmdb_watchlist, key="TMDB_ID")
+            
             # If remove_watched_from_watchlists_value is true
             if remove_watched_from_watchlists_value:        
                 # Get the IDs from watched_content

--- a/TMDBTraktSyncer/errorHandling.py
+++ b/TMDBTraktSyncer/errorHandling.py
@@ -333,6 +333,21 @@ def filter_mismatched_items(trakt_list, tmdb_list):
 
     return filtered_trakt_list, filtered_tmdb_list
     
+def filter_items(source_list, target_list, key="TMDB_ID"):
+    """
+    Filters items from the target_list that are not already present in the source_list based on a key.
+
+    Args:
+        source_list (list): The list whose elements are used to filter the target_list.
+        target_list (list): The list to be filtered.
+        key (str): The key to identify unique elements. Defaults to "TMDB_ID".
+
+    Returns:
+        list: A filtered list containing items from the target_list that are not in the source_list.
+    """
+    source_set = {item[key] for item in source_list}
+    return [item for item in target_list if item[key] not in source_set]
+    
 def sort_by_date_added(items, descending=False):
     """
     Sorts a list of items by the 'Date_Added' field.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TMDBTraktSyncer"
-version = "2.2.2"
+version = "2.2.3"
 description = "A python script that syncs user watchlist and ratings for Movies, TV Shows and Episodes both ways between Trakt and TMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
- Move filtering to its own function and use temporary sets and set lookups to speedup filtering similar to PR in IMDB-Trakt-Syncer as mentioned https://github.com/RileyXX/IMDB-Trakt-Syncer/pull/149